### PR TITLE
layouts: fix a text of link, remove a redundant word

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
     <div class="col-lg-9 col-xl-8 text-center">
       <p class="lead">{{ .Params.lead | safeHTML }}</p>
       <a class="btn btn-primary btn-lg px-4 mb-2" href="/docs/{{ if .Site.Params.options.docsVersioning }}{{ .Site.Params.docsVersion }}/{{ end }}prologue/introduction/" role="button">Get Started</a>
-      <p class="meta">Get the source <a href="https://github.com/cloud-hypervsior"> on GitHub</a></p>
+      <p class="meta">Get the source on <a href="https://github.com/cloud-hypervsior">GitHub</a></p>
     </div>
   </div>
 </section>
@@ -48,7 +48,7 @@
       <div class="row justify-content-center text-center">
         <div class="col-lg-5">
           <h2 class="h4">Cross platform</h2>
-          <p>Runs on both 64-bit x86-64 and aarch64</p>
+          <p>Runs on both x86-64 and aarch64</p>
         </div>
         <div class="col-lg-5">
           <h2 class="h4">Broad device support</h2>


### PR DESCRIPTION
The link of repo should be on `GitHub` instead of `on GitHub`. And with description of `x86-64` and `aarch64`, the `64-bit` is redundant.

Old link and description in home page:

> Get the source [on GitHub](https://github.com/cloud-hypervsior)
>
> Runs on both 64-bit x86-64 and aarch64

Fixed home page:

> Get the source on [GitHub](https://github.com/cloud-hypervsior)
>
> Runs on both x86-64 and aarch64

Signed-off-by: Yu Li \<liyu.yukiteru@bytedance.com\>