### PR TITLE
Update quick-start.md

### DIFF
--- a/content/en/docs/prologue/quick-start.md
+++ b/content/en/docs/prologue/quick-start.md
@@ -19,6 +19,8 @@ We create a folder to build and run `cloud-hypervisor` at `$HOME/cloud-hyperviso
 
 ```shell
 export CLOUDH=$HOME/cloud-hypervisor
+# Add this to .bashrc so it is available for subsequent bash sessions
+echo "export CLOUDH=$HOME/cloud-hypervisor" >> ~/.bashrc
 mkdir $CLOUDH
 ```
 
@@ -35,7 +37,15 @@ sudo apt install git
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 # Install build-essential
 sudo apt install build-essential
+# Install qemu
+apt install qemu qemu-utils
+```
+
+You will need to restart bash to get `rustup` into your path, or add it manually.
+
+```shell
 # If you want to build statically linked binary please add musl target
+apt install musl musl-tools
 rustup target add x86_64-unknown-linux-musl
 ```
 
@@ -119,7 +129,7 @@ sudo setcap cap_net_admin+ep ./cloud-hypervisor/target/release/cloud-hypervisor
 	--cpus boot=4 \
 	--memory size=1024M \
 	--net "tap=,mac=,ip=,mask=" \
-	--rng
+	--rng src=/dev/urandom
 popd
 ```
 
@@ -174,7 +184,7 @@ sudo setcap cap_net_admin+ep ./cloud-hypervisor/target/release/cloud-hypervisor
 	--cpus boot=4 \
 	--memory size=1024M \
 	--net "tap=,mac=,ip=,mask=" \
-	--rng
+	--rng src=/dev/urandom
 ```
 
 The above example use the `virtio-console` device as the guest console, and this
@@ -194,5 +204,5 @@ console is preferred:
 	--cpus boot=4 \
 	--memory size=1024M \
 	--net "tap=,mac=,ip=,mask=" \
-	--rng
+	--rng src=/dev/urandom
 ```

--- a/content/en/docs/prologue/quick-start.md
+++ b/content/en/docs/prologue/quick-start.md
@@ -128,8 +128,7 @@ sudo setcap cap_net_admin+ep ./cloud-hypervisor/target/release/cloud-hypervisor
 	--disk path=focal-server-cloudimg-amd64.raw \
 	--cpus boot=4 \
 	--memory size=1024M \
-	--net "tap=,mac=,ip=,mask=" \
-	--rng src=/dev/urandom
+	--net "tap=,mac=,ip=,mask="
 popd
 ```
 
@@ -183,8 +182,7 @@ sudo setcap cap_net_admin+ep ./cloud-hypervisor/target/release/cloud-hypervisor
 	--cmdline "console=hvc0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
-	--net "tap=,mac=,ip=,mask=" \
-	--rng src=/dev/urandom
+	--net "tap=,mac=,ip=,mask="
 ```
 
 The above example use the `virtio-console` device as the guest console, and this
@@ -203,6 +201,5 @@ console is preferred:
 	--cmdline "console=ttyS0 root=/dev/vda1 rw" \
 	--cpus boot=4 \
 	--memory size=1024M \
-	--net "tap=,mac=,ip=,mask=" \
-	--rng src=/dev/urandom
+	--net "tap=,mac=,ip=,mask="
 ```


### PR DESCRIPTION
After testing these instructions from a fresh Ubuntu 20.04 server install, I propose these changes:
- add `CLOUDH` to .bashrc to make the instructions work even if the user has to close the current session and open a new one to reflect path changes from the rust installer
- add instructions to close and re-open bash to allow `rustup` to appear on the path
- add qemu and qemu-utils as pre-requisites so the image conversion instructions work without troubleshooting/going back to install them
- correct `--rng` arguments as the current arguments resulted in an error: "error: The argument '--rng <rng>' requires a value but none was supplied"

