### PR TITLE
content: add Cyberus Technology to Supporting Organisations

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,6 +77,7 @@
           <li>Ampere</li>
           <li>ARM</li>
           <li>ByteDance</li>
+          <li>Cyberus Technology</li>
           <li>Intel</li>
           <li>Microsoft</li>
           <li>Tencent Cloud</li>


### PR DESCRIPTION
As discussed via email, this adds Cyberus Technology to the list of supporting organisations.

Excerpt from our email:

> We highly value the collaboration within the Cloud Hypervisor community and are committed to supporting the project long-term, both through our direct contributions and our involvement in EU-funded initiatives such as IPCEI and ApeiroRA (https://apeirora.eu/).