### PR TITLE
content: add SAP to Supporting Organisations

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -80,6 +80,7 @@
           <li>Cyberus Technology</li>
           <li>Intel</li>
           <li>Microsoft</li>
+          <li>SAP</li>
           <li>Tencent Cloud</li>
         </ul>
 


### PR DESCRIPTION
Although contributions to Cloud Hypervisor are submitted using Cyberus Technology email addresses, the majority of this work is sponsored by SAP. To reflect their significant support in enabling these contributions, we would like to add SAP to the list of Supporting Organisations.

SAP's inclusion here has been approved by David Höller <david.hoeller@sap.com> via email on 2025-09-21 16:38 CEST.
