### PR TITLE
doc: streamline --firmware and --kernel

### DIFF
--- a/content/en/docs/prologue/quick-start.md
+++ b/content/en/docs/prologue/quick-start.md
@@ -92,7 +92,7 @@ interface will be enabled as per `network-config` details.
 $ sudo setcap cap_net_admin+ep ./cloud-hypervisor
 $ ./create-cloud-init.sh
 $ ./cloud-hypervisor \
-	--kernel ./hypervisor-fw \
+	--firmware ./hypervisor-fw \
 	--disk path=focal-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cpus boot=4 \
 	--memory size=1024M \
@@ -105,7 +105,7 @@ GRUB) is required then it necessary to switch to the serial console instead of
 
 ```shell
 $ ./cloud-hypervisor \
-	--kernel ./hypervisor-fw \
+	--firmware ./hypervisor-fw \
 	--disk path=focal-server-cloudimg-amd64.raw path=/tmp/ubuntu-cloudinit.img \
 	--cpus boot=4 \
 	--memory size=1024M \


### PR DESCRIPTION
This aligns the documentation with Cloud Hypervisor's [0]. Although both parameters currently use the same underlying loading function, this may change in the future. Keeping them separate makes it clearer what is happening.

[0] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7166/changes/a9818be9f1875ea93d85e62196863e0652e48148
